### PR TITLE
Add DIP-SW, reproduce logic related to game start/end.

### DIFF
--- a/Arcade-ComputerSpace.sv
+++ b/Arcade-ComputerSpace.sv
@@ -197,8 +197,8 @@ localparam CONF_STR = {
 	"O2,Color,No,Yes;",
 	"-;",
 	"R0,Reset;",
-	"J1,Thrust,Fire,Start;",
-	"jn,B,A,Start;",
+	"J1,Thrust,Fire,Start,Coin;",
+	"jn,B,A,Start,R;",
 	"V,v",`BUILD_DATE
 };
 
@@ -246,6 +246,7 @@ wire m_right  = joy[0];
 wire m_thrust = joy[4];
 wire m_fire   = joy[5];
 wire m_start  = joy[6];
+wire m_coin   = joy[7];
 
 wire HBlank, VBlank;
 wire VSync, HSync;
@@ -285,6 +286,7 @@ computer_space_top computerspace
 	.signal_thrust(m_thrust),
 	.signal_fire(m_fire),
 	.signal_start(m_start),
+	.signal_coin(m_coin),
 
 	.hsync(HSync),
 	.vsync(VSync),

--- a/Arcade-ComputerSpace.sv
+++ b/Arcade-ComputerSpace.sv
@@ -196,6 +196,8 @@ localparam CONF_STR = {
 	"O34,Aspect ratio,Original,Full Screen,[ARC1],[ARC2];",
 	"O2,Color,No,Yes;",
 	"-;",
+  "DIP;",
+	"-;",
 	"R0,Reset;",
 	"J1,Thrust,Fire,Start,Coin;",
 	"jn,B,A,Start,R;",
@@ -226,6 +228,11 @@ wire [21:0] gamma_bus;
 wire [15:0] joystick_0, joystick_1;
 wire [15:0] joy = joystick_0 | joystick_1;
 
+wire        ioctl_wr;
+wire [26:0] ioctl_addr;
+wire  [7:0] ioctl_dout;
+wire [15:0] ioctl_index;
+
 hps_io #(.STRLEN($size(CONF_STR)>>3)) hps_io
 (
 	.clk_sys(clk_sys),
@@ -237,6 +244,11 @@ hps_io #(.STRLEN($size(CONF_STR)>>3)) hps_io
 	.status(status),
 	.gamma_bus(gamma_bus),
 
+	.ioctl_wr,
+	.ioctl_addr,
+	.ioctl_dout,
+	.ioctl_index,
+
 	.joystick_0(joystick_0),
 	.joystick_1(joystick_1)
 );
@@ -247,6 +259,15 @@ wire m_thrust = joy[4];
 wire m_fire   = joy[5];
 wire m_start  = joy[6];
 wire m_coin   = joy[7];
+
+// Load DIP-SW
+reg [7:0] dipsw[8];
+always @(posedge clk_sys) begin
+  if (ioctl_wr && (ioctl_index==254) && !ioctl_addr[24:3])
+    dipsw[ioctl_addr[2:0]] <= ioctl_dout;
+end
+wire sw_2playpercoin = dipsw[0][0];
+wire sw_replay = dipsw[0][1];
 
 wire HBlank, VBlank;
 wire VSync, HSync;
@@ -287,6 +308,9 @@ computer_space_top computerspace
 	.signal_fire(m_fire),
 	.signal_start(m_start),
 	.signal_coin(m_coin),
+
+	.sw_2playpercoin(sw_2playpercoin),
+	.sw_replay(sw_replay),
 
 	.hsync(HSync),
 	.vsync(VSync),

--- a/releases/Computer Space.mra
+++ b/releases/Computer Space.mra
@@ -2,9 +2,10 @@
 	<name>Computer Space</name>
 	<mameversion>0216</mameversion>
 	<setname></setname>
-	<mratimestamp>201911270000</mratimestamp>
+	<mratimestamp>202101130000</mratimestamp>
 	<year>1971</year>
 	<manufacturer>Syzygy Engineering</manufacturer>
 	<category>Simulation</category>
 	<rbf>computerspace</rbf>
+	<buttons names="Thrust,Fire,Start,Coin" default="B,A,Start,R"/>
 </misterromdescription>

--- a/releases/Computer Space.mra
+++ b/releases/Computer Space.mra
@@ -7,5 +7,9 @@
 	<manufacturer>Syzygy Engineering</manufacturer>
 	<category>Simulation</category>
 	<rbf>computerspace</rbf>
+	<switches default="02">
+		<dip bits="0" name="2PlayPerCoin" ids="Off,On"/>
+		<dip bits="1" name="Replay" ids="Off,On"/>
+	</switches>
 	<buttons names="Thrust,Fire,Start,Coin" default="B,A,Start,R"/>
 </misterromdescription>

--- a/rtl/computer_space_logic.vhd
+++ b/rtl/computer_space_logic.vhd
@@ -51,6 +51,9 @@ entity computer_space_logic is
 	signal_start, signal_coin,
 	signal_thrust, signal_fire,
 	signal_cw, signal_ccw  						: in std_logic;
+
+	-- setting switches
+	sw_2playpercoin, sw_replay					: in std_logic;
 	
 	-- composite video
 	-- signals; to send via gpio
@@ -86,7 +89,7 @@ component sync_star_board
 	explosion_clk, seconds_clk					: in std_logic; 
 
 	SB_3, SB_4, SB_6, SB_7,
-	SB_C, SB_E, SB_N								: in std_logic;  	
+	SB_C, SB_D, SB_E, SB_F, SB_N						: in std_logic;  	
 
 	SB_2, SB_5, SB_H, SB_K,
 	SB_L, SB_M, SB_Y 								: out std_logic;  
@@ -149,7 +152,7 @@ end component;
 -- signals for interfacing
 -- with sync star board
 signal SB_3, SB_4, SB_6,
-		 SB_C, SB_E, SB_N							: std_logic;   
+		 SB_C, SB_D, SB_E, SB_F, SB_N				: std_logic;   
 signal SB_2, SB_5, SB_7,
 		 SB_H, SB_K, SB_L, SB_M, SB_Y			: std_logic;   
 
@@ -193,7 +196,7 @@ begin
 -----------------------------------------------------------------------------
 Sync_Star_Brd : sync_star_board 
 port map (reset, game_clk, super_clk, explosion_clk, seconds_clk,
-SB_3, SB_4, SB_6, SB_7, SB_C, SB_E, SB_N,
+SB_3, SB_4, SB_6, SB_7, SB_C, SB_D, SB_E, SB_F, SB_N,
 SB_2, SB_5, SB_H, SB_K, SB_L, SB_M, SB_Y, hsync, vsync,
 composite_video_signal, hblank, vblank);
 
@@ -353,5 +356,11 @@ sound_switch (3) <= MB_2_rocket; 	-- rocket missile shooting
 sound_switch (4) <= MemBrd_22; 		-- explosion
 sound_switch (5) <= MB_2_saucer;		-- saucer missile shooting	
 sound_switch (6) <= '0';
+
+-----------------------------------------------------------------------------
+-- CONNECTING TO SETTING SWITCHES
+-----------------------------------------------------------------------------
+SB_D <= sw_2playpercoin;
+SB_F <= sw_replay;
 
 end computer_space_logic_architecture;

--- a/rtl/computer_space_top.vhd
+++ b/rtl/computer_space_top.vhd
@@ -100,6 +100,9 @@ entity computer_space_top is
 		signal_start 	: in  std_logic;
 		signal_coin     : in  std_logic;
 
+		sw_2playpercoin : in  std_logic;
+		sw_replay       : in  std_logic;
+
 		hsync				: out std_logic;
 		vsync				: out std_logic;
 		hblank			: out std_logic;
@@ -143,6 +146,7 @@ component computer_space_logic is
 	signal_start, signal_coin, 
 	signal_thrust, signal_fire,
 	signal_cw, signal_ccw  						: in std_logic;
+	sw_2playpercoin, sw_replay					: in std_logic;
 	composite_video_signal					 	: out std_logic_vector(3 downto 0);
 	hblank,vblank									: out std_logic;
 	hsync												: out std_logic;
@@ -231,7 +235,7 @@ rocket_missile_life_time_duration, saucer_missile_life_time_duration,
 saucer_missile_hold_duration, signal_delay_duration,
 thrust_and_rotate_clk, explosion_rotate_clk, 
 signal_start, signal_coin, signal_thrust, signal_fire,
-signal_cw,signal_ccw, video, hblank, vblank,
+signal_cw,signal_ccw, sw_2playpercoin, sw_replay, video, hblank, vblank,
 hsync, vsync,
 audio_gate, sound_switch, saucer_missile_sound,rocket_missile_sound,
 turn_sound

--- a/rtl/computer_space_top.vhd
+++ b/rtl/computer_space_top.vhd
@@ -98,6 +98,7 @@ entity computer_space_top is
 		signal_thrust 	: in  std_logic;
 		signal_fire 	: in  std_logic;
 		signal_start 	: in  std_logic;
+		signal_coin     : in  std_logic;
 
 		hsync				: out std_logic;
 		vsync				: out std_logic;
@@ -229,7 +230,7 @@ port map
 rocket_missile_life_time_duration, saucer_missile_life_time_duration,
 saucer_missile_hold_duration, signal_delay_duration,
 thrust_and_rotate_clk, explosion_rotate_clk, 
-signal_start, signal_start, signal_thrust, signal_fire,
+signal_start, signal_coin, signal_thrust, signal_fire,
 signal_cw,signal_ccw, video, hblank, vblank,
 hsync, vsync,
 audio_gate, sound_switch, saucer_missile_sound,rocket_missile_sound,

--- a/rtl/sync_star_board.vhd
+++ b/rtl/sync_star_board.vhd
@@ -239,7 +239,7 @@ signal a5_3_1, b5_3_1, b5_11_13,
 -- signals for start/end game
 -- circuitry logic
 signal SB_D, SB_B 								: std_logic;
---signal SB_7_old 						: std_logic :='1';
+signal SB_7_old 						: std_logic :='1';
 signal SB_C_old 						: std_logic :='1';
 
 -- game clock
@@ -1254,7 +1254,7 @@ if reset = '1' then
 	e5_12 <= '0';
 	d6_8 <= '0';
 elsif rising_edge (super_clk) then
-	--SB_7_old <= SB_7;
+	SB_7_old <= SB_7;
 	SB_C_old <= SB_C;
 	
 	case state is
@@ -1269,10 +1269,10 @@ elsif rising_edge (super_clk) then
 		when COIN_INSERTED =>   
 			d6_8 <= '1';
 			e5_12 <= '1';
-			--if SB_7_old = '0' and SB_7 = '1' then 
+			if SB_7_old = '0' and SB_7 = '1' then 
 				d6_8 <= '0';
 				state <= GAME_ON;
-			--end if;		
+			end if;		
 			
 		when GAME_ON =>  
 			d6_8 <= '1';

--- a/rtl/sync_star_board.vhd
+++ b/rtl/sync_star_board.vhd
@@ -83,11 +83,13 @@ entity sync_star_board is
 							-- rocket missile  
 	SB_7,					-- "start button pressed" signal
 	SB_C,					-- "coin inserted" signal
+	SB_D,					-- 2PlayPerCoin SW
 	SB_E,					-- Rocket Enable 
 							-- signals that the TV beam
 							-- is "sweeping" by the current 
 							-- position of the 16 x 16 pixel
 							-- rocket image grid
+	SB_F,					-- Replay SW
 	SB_N					-- rocket & saucer video mix signal
 																				: in std_logic;   
 	
@@ -142,11 +144,6 @@ component scan_counter is
 	vertical, horizontal 						: out std_logic_vector (7 downto 0)
 	);
 end component;
-
--- statemachine for coin detection,
--- start game and indicate "game on" 
-type STATE_TYPE is
-(IDLE, COIN_INSERTED, GAME_ON);
 
 signal count_enable, a1_15, c4_14 			: std_logic;
 
@@ -208,8 +205,6 @@ signal a2_3, a2_4, a2_5, a2_6,
 		 a2_13, a2_15 								: std_logic;
 signal c2_11 										: std_logic;
 
-signal SB_F 										: std_logic;
-
 -- signals for explosion circuitry logic
 signal a6_8, h2_1, a6_3, a6_11,
 		 a6_6, e2_13, e2_4,
@@ -238,7 +233,7 @@ signal a5_3_1, b5_3_1, b5_11_13,
 
 -- signals for start/end game
 -- circuitry logic
-signal SB_D, SB_B 								: std_logic;
+signal SB_B 								: std_logic;
 signal SB_7_old 						: std_logic :='1';
 signal SB_C_old 						: std_logic :='1';
 
@@ -259,9 +254,7 @@ signal d5_6 										: std_logic :='1';
 signal d5_13, d5_11, d5_12, d5_10 			: std_logic;
 signal d5_9 										: std_logic := '0';
 signal d5_8 										: std_logic := '1';
-signal c6_5, c6_6, c6_1 						: std_logic;
-
-signal state 										: STATE_TYPE := IDLE;
+signal c6_5, c6_5_old, c6_6, c6_1, c6_1_old			: std_logic;
 
 -- signals to manage asynchronous
 -- clock design embedded in
@@ -1232,63 +1225,156 @@ a2_15 <= '1' when a2_A > a2_B else '0';
 -----------------------------------------------------------------------------
 -- REPLAY CIRCUITRY:	Set Replay or not													-- 
 --																									--
--- SB_F = '1'; flag allows for replay													--
+-- SB_F connected to switch allows for replay													--
 -----------------------------------------------------------------------------
-SB_F <= '1';
 c2_11 <= SB_F and a2_15; -- determine replay or not, depending on score
 
+
 -----------------------------------------------------------------------------
--- START/END GAME: Start Game Process													--
---																									--
--- start game circuitry is not fully reproduced										--
--- a "state machine" represents the logic												--
---																									--	
--- SB_7 connected to Start button  on player control panel.						--
---																									--
--- SB_C connected to coin microswitch													--
------------------------------------------------------------------------------	
+-- START/END GAME: Coin Latch
+--
+-- A tricky latch constructed with relay and transistor(Q13).
+--
+-- The actual output is active low but it is only used via inverter e5_12,
+-- at last it turns active high.
+--
+-- Note: This digital reproduction directly outputs inverted e5_12 signal.
+--
+-- e5_12 determines whether or not the game can be started
+-- when the start button is pressed via RS flip-flop(d6_8).
+--
+-- Also it is used to keep reset the following two D-FFs until a coin inserted.
+--  d5_6(Replay Flag)
+--  d5_9(Game On/Off Flag)
+--
+--
+-- Transition of actual output (and e5_12):
+--
+-- < Initial state: High (e5_12: Low) >
+-- Because CoinSwitchNO is open(or VCC), there is no current through relay.
+-- So relay is open, resulting output keeping high.
+--
+-- < Transition to Low (e5_12: High) >
+-- Once a coin inserted(that is, CoinSwitchNO falls GND), relay turns on (closes).
+-- Transistor(Q13) is always conducted state to GND except latch clear signal(c5_3)
+-- is turns low at the end of the game.
+-- Therefore, when relay closes, the latch output stuck GND via Q13,
+-- even though CoinSwitchNO is back to high.
+--
+-- < Transition to High (e5_12: Low) >
+-- When the game is over, latch clear signal(c5_3) turns low,
+-- resulting transistor(Q13) to be non-conducting state.
+-- Then CoinSwitchNO turns high, relay turns off(opens),
+-- and the latch output keeps high after that.
+--
+--
+-- SB_C connected to coin microswitch
+-- e5_12 is inverted latch output
+-----------------------------------------------------------------------------
 process (super_clk, reset)
 begin
 if reset = '1' then
-	state <= IDLE;
 	e5_12 <= '0';
-	d6_8 <= '0';
 elsif rising_edge (super_clk) then
-	SB_7_old <= SB_7;
-	SB_C_old <= SB_C;
-	
+	if SB_C = '1' then
+		e5_12 <= '1';
+	elsif c5_3 = '0' then
+		e5_12 <= '0';
+	end if;
+end if;
+end process;
+
+-----------------------------------------------------------------------------
+-- START/END GAME: Coin Latch Clear
+--
+-- 1. C6(74121 monostable multivibrator) outputs about 280,000 ns pulse -
+--    triggered by rising edge of c6_5 (game end)
+--
+-- 2. A5(7474 D-FF) outputs
+--    * 2playpercoin sw is off
+--        always high
+--    * 2playpercoin sw is on
+--        alternate high and low changing at the end of each game end 
+--
+-- 3. C5_3(NAND gates) outputs
+--    * 2playpercoin sw is off
+--        coin latch clear pulse(active low) at every game end
+--    * 2playpercoin sw is on
+--        coin latch clear pulse(active low) once every two times at game end
+--
+-- SB_D connected to 2 Play per coin SW
+-- c5_3 is coin latch clear signal (active low)
+-----------------------------------------------------------------------------
+C6_74121 : process (super_clk, reset)
+	type t_state is (IDLE, COUNT);
+	variable state : t_state := IDLE;
+	constant cnt_end : integer range 0 to 16383 := 14000; -- 280,000 ns / 20 ns
+	variable cnt : integer range 0 to 16383;
+begin
+if reset = '1' then
+	c6_6 <= '0';
+	c6_1 <= '1';
+	state := IDLE;
+	cnt := 0;
+elsif rising_edge (super_clk) then
+	c6_5_old <= c6_5;
 	case state is
 		when IDLE =>
-			e5_12 <= '0';
-			d6_8 <= '1';
-			if SB_C_old = '0' and SB_C = '1' then
-				e5_12 <= '1';
-				state <= COIN_INSERTED;
+			c6_6 <= '0';
+			c6_1 <= '1';
+			if (c6_5_old = '0' and c6_5 = '1') then
+				state := COUNT;
+				cnt := 0;
 			end if;
-		
-		when COIN_INSERTED =>   
-			d6_8 <= '1';
-			e5_12 <= '1';
-			if SB_7_old = '0' and SB_7 = '1' then 
-				d6_8 <= '0';
-				state <= GAME_ON;
-			end if;		
-			
-		when GAME_ON =>  
-			d6_8 <= '1';
-			e5_12 <= '1';
-			if d5_9 = '0' then
-				state <= IDLE;
-				e5_12 <= '0';			
-			end if;		
-
-		when others =>          
-			state <= IDLE;
-			e5_12 <= '0';
-			d6_8 <= '1';
-				
+		when COUNT =>
+			c6_6 <= '1';
+			c6_1 <= '0';
+			cnt := cnt + 1;
+			if (cnt = cnt_end) then
+				state := IDLE;
+			end if;
+		when others =>
+			state := IDLE;
 	end case;
-end if;	
+end if;
+end process;
+
+A5_7474 : process (super_clk, reset, SB_D)
+begin
+if reset = '1' then
+	a5_9 <= '0';
+elsif SB_D = '0' then
+	a5_9 <= '1';
+elsif rising_edge (super_clk) then
+	c6_1_old <= c6_1;
+	if (c6_1_old = '0' and c6_1 = '1') then
+		a5_9 <= not(a5_9);
+	end if;
+end if;
+end process;
+
+c5_3 <= not(c6_6 and a5_9);
+
+-----------------------------------------------------------------------------
+-- START/END GAME: Start Button Latch
+--
+-- RS-FF made of 4-Input NAND to make start game pulse(active low)
+--
+-- Outputs low while start button is pressed, otherwise outputs high.
+--
+-- Pressing start button is ignored in the following conditions
+-- * Coin latch output (e5_12) is low, which means no credit
+-- * Inverted game on/off flag(d5_8) is low, which means game has already started
+--
+-- SB_7 connected to Start button  on player control panel.
+-- d6_8 outputs game start pulse(active low)
+-----------------------------------------------------------------------------
+process (SB_7, e5_12, d5_8) begin
+	if (SB_7 = '1' and e5_12 = '1' and d5_8 = '1') then
+		d6_8 <= '0';
+	else
+		d6_8 <= '1';
+	end if;
 end process;
 
 -----------------------------------------------------------------------------
@@ -1354,6 +1440,8 @@ begin
 		end if;
 	end if;
 end process;
+
+c6_5 <= d5_8;
 
 -----------------------------------------------------------------------------
 -- START/END GAME: Reset Score and Time (Unit and Tens)							--


### PR DESCRIPTION
Added 2 DIP-SW settings.

### 2 play per coin sw 
- This sw was not implemented in original Mattias G version.
- The reason is that game start/end logic, which is closely related to this sw, was not fully reproduced.
- In order to get this sw work correctly, I seperated coin sw.

### Replay sw
- This sw was internally always on in original Mattias G version.


